### PR TITLE
update spacing for nato alphabet hints

### DIFF
--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -182,9 +182,9 @@ export default function Card({
           </p>
         )}
         {referenceType == "nato" && (
-          <p className="italic lowercase text-sm select-none flex flex-row gap-2 -my-1 ml-0.5 z-10 h-7">
+          <p className="italic lowercase text-sm select-none flex flex-row -my-1 ml-0.5 z-10 h-7">
             {[...displayCallsign].map((c, i) => (
-              <span key={i}>{NATO_ALPHABET[c.toLocaleUpperCase()]}</span>
+              <div key={i} className="w-[43px] text-center">{NATO_ALPHABET[c.toLocaleUpperCase()]}</div>
             ))}
           </p>
         )}


### PR DESCRIPTION
Before:
<img width="360" alt="image" src="https://github.com/breqdev/callsign-rolodex/assets/56163633/50761347-863b-432c-89ce-de8660200039">


After:
<img width="367" alt="image" src="https://github.com/breqdev/callsign-rolodex/assets/56163633/126ebd1e-7c01-4490-9874-f1abfcc8de81">
